### PR TITLE
feat: OpenAICompatibleProvider에서 gpt-5-codex에 대한 지원 추가

### DIFF
--- a/providers/openai_provider.py
+++ b/providers/openai_provider.py
@@ -22,6 +22,25 @@ class OpenAIModelProvider(OpenAICompatibleProvider):
 
     # Model configurations using ModelCapabilities objects
     SUPPORTED_MODELS = {
+        # https://platform.openai.com/docs/models/gpt-5-codex
+        "gpt-5-codex": ModelCapabilities(
+            provider=ProviderType.OPENAI,
+            model_name="gpt-5-codex",
+            friendly_name="OpenAI (GPT-5 Codex)",
+            context_window=400_000,  # 400K tokens
+            max_output_tokens=128_000,  # 128K max output tokens
+            supports_extended_thinking=True,  # Supports reasoning tokens
+            supports_system_prompts=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            supports_json_mode=True,
+            supports_images=True,  # GPT-5-Codex supports vision
+            max_image_size_mb=20.0,  # 20MB per OpenAI docs
+            supports_temperature=True,  # Regular models accept temperature parameter
+            temperature_constraint=create_temperature_constraint("fixed"),
+            description="GPT-5 Codex (400K context, 128K output) - Advanced model with reasoning support",
+            aliases=["gpt5-codex", "gpt-5-codex"],
+        ),
         "gpt-5": ModelCapabilities(
             provider=ProviderType.OPENAI,
             model_name="gpt-5",


### PR DESCRIPTION
## Summary
OpenAI의 GPT-5 Codex 모델 지원 추가

## Changes
- **OpenAI Provider**: GPT-5 Codex 모델 정의 추가 (`providers/openai_provider.py`)
  - 400K 컨텍스트 윈도우, 128K 최대 출력 토큰 지원
  - 확장된 사고(reasoning tokens) 지원
  - 비전(이미지) 기능 지원 (최대 20MB)
  - 함수 호출, JSON 모드, 스트리밍 지원
  - 별칭: `gpt5-codex`, `gpt-5-codex`

- **OpenAI Compatible Provider**: GPT-5 Codex용 `/v1/responses` 엔드포인트 지원 (`providers/openai_compatible.py`)
  - `o3-pro`와 동일한 방식으로 `gpt-5-codex` 처리
  - 비전 모델 목록에 추가
  - 에러 메시지 및 주석 업데이트